### PR TITLE
Merge pico searchspace with hw constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,4 @@ cython_debug/
 
 #Vscode
 .vscode/
+.cspell/

--- a/config_files/config_defaults/default_hwnas_config.yaml
+++ b/config_files/config_defaults/default_hwnas_config.yaml
@@ -2,4 +2,4 @@ HWNASConfig:
   host_processor: "auto" 
   max_search_trials: 4
   top_n_models: 2
-
+  hw_constraints: {"max_flops": 10e9, "max_params": 1e6}

--- a/config_files/config_templates/hwnas_config.yaml
+++ b/config_files/config_templates/hwnas_config.yaml
@@ -1,7 +1,7 @@
 # HWNASConfig that defines the HW-Nas Behavior.
 # If parameters are not specified inside the config, they are set to default values.
 HWNASConfig:
-  #Processor type (cpu, cuda:n) of the host, the experiment should run on.
+  # Processor type (cpu, cuda:n) of the host that the experiment should run on.
   host_processor: "auto" 
 
   # The search trials the HW-NAS should do at max.
@@ -9,4 +9,8 @@ HWNASConfig:
 
   # The number of top models returned by HW-NAS.
   top_n_models: 2
-
+  
+  # The hardware constraints for the search.
+  # Currently, only "max_flops" and "max_params" are supported.
+  # Max. capabilities of Raspberry Pi platforms: RPi4 ~ 4.4 GFLOPS, RPi5 ~ 10 GFLOPS.
+  hw_constraints: {"max_flops": 10e9, "max_params": 1e6}

--- a/elasticai/explorer/config.py
+++ b/elasticai/explorer/config.py
@@ -70,8 +70,9 @@ class HWNASConfig(Config):
         ),
     ):
         super().__init__(config_path)
-        self._original_yaml_dict = self._parse_optional("HWNASConfig", {})
+        self._original_yaml_dict: dict = self._parse_optional("HWNASConfig", {})
         self.host_processor: str = self._parse_optional("host_processor", "auto")
+        self.hw_constraints: dict = self._parse_optional("hw_constraints", {})
         if self.host_processor == "auto":
             self.host_processor = "cuda" if torch.cuda.is_available() else "cpu"
         self.max_search_trials: int = self._parse_optional("max_search_trials", 6)

--- a/elasticai/explorer/explorer.py
+++ b/elasticai/explorer/explorer.py
@@ -51,7 +51,7 @@ class Explorer:
             self.experiment_name: str = experiment_name
 
     @property
-    def experiment_name(self):
+    def experiment_name(self): # type: ignore
         return self._experiment_name
 
     @property
@@ -71,7 +71,7 @@ class Explorer:
         return self._plot_dir
 
     @experiment_name.setter
-    def experiment_name(self, value: str):
+    def experiment_name(self, value: str): # type: ignore
         """Setting experiment name updates the experiment pathes aswell."""
         self._experiment_name: str = value
         self._experiment_dir: Path = MAIN_EXPERIMENT_DIR / self._experiment_name

--- a/elasticai/explorer/hw_nas/hw_nas.py
+++ b/elasticai/explorer/hw_nas/hw_nas.py
@@ -1,12 +1,16 @@
 import logging
 import math
-from typing import Any
+from typing import Any, Callable, cast
 
 import nni
 import torch
-from nni.nas import strategy
+from nni.nas.strategy import Random
+from nni.nas.strategy.middleware import Filter, Chain
 from nni.nas.evaluator import FunctionalEvaluator
 from nni.nas.experiment import NasExperiment
+from nni.experiment import TrialResult
+from nni.nas.nn.pytorch import ModelSpace
+from nni.nas.space import ExecutableModelSpace, SimplifiedModelSpace
 from nni.experiment import TrialResult
 from nni.nas.nn.pytorch import ModelSpace
 from torch.utils.data import DataLoader
@@ -14,13 +18,13 @@ from torchvision.datasets import MNIST
 from torchvision.transforms import transforms
 
 from elasticai.explorer.config import HWNASConfig
-from elasticai.explorer.hw_nas.cost_estimator import FlopsEstimator
+from elasticai.explorer.hw_nas.cost_estimator import CostEstimator
 from elasticai.explorer.trainer import MLPTrainer
 
 logger = logging.getLogger("explorer.nas")
 
 
-def evaluate_model(model: torch.nn.Module, device: str):
+def evaluate_model(model: ModelSpace, device: str):
     global accuracy
     flops_weight = 3.0
     n_epochs = 2
@@ -38,9 +42,8 @@ def evaluate_model(model: torch.nn.Module, device: str):
         MNIST("data/mnist", download=True, train=False, transform=transf), batch_size=64
     )
     trainer = MLPTrainer(device, optimizer)
-    flops_estimator = FlopsEstimator()
-    sample, _ = next(iter(train_loader))
-    flops = flops_estimator.estimate_flops(model, sample)
+    cost_estimator = CostEstimator()
+    flops = cost_estimator.estimate_flops(model)
     metric = {"default": 0, "accuracy": 0, "flops log10": math.log10(flops)}
     for epoch in range(n_epochs):
         trainer.train_epoch(model, train_loader, epoch)
@@ -59,7 +62,30 @@ def search(
     """
     Returns: top-models, model-parameters, metrics
     """
-    search_strategy = strategy.Random()
+    
+    filters: list[Filter] = []
+    cost_estimator = CostEstimator()
+
+    def make_filter(model_space: ModelSpace, max_val: float | str, estimate: Callable[[ModelSpace], float]) -> Filter:
+        def constraint(sample: SimplifiedModelSpace) -> bool:
+            assert sample.sample is not None
+            frozen_model = cast(ModelSpace, model_space.freeze(sample.sample))
+            return estimate(frozen_model) < float(max_val)
+        return Filter(cast(Callable[[ExecutableModelSpace], bool], constraint)) 
+
+    for key, value in hwnas_cfg.hw_constraints.items():
+        if key == "max_flops":
+            filters.append(make_filter(search_space, value, cost_estimator.estimate_flops))
+        elif key == "max_params":
+            filters.append(make_filter(search_space, value, cost_estimator.compute_num_params))
+        else:
+            logger.warning("Unknown hardware constraint: %s", key)
+    
+    if not filters:
+        search_strategy = Random()
+    else:
+        search_strategy = Chain(Random(), *filters)
+
     evaluator = FunctionalEvaluator(evaluate_model, device=hwnas_cfg.host_processor)
     experiment = NasExperiment(search_space, evaluator, search_strategy)
     experiment.config.max_trial_number = hwnas_cfg.max_search_trials

--- a/tests/integration_tests/test_configs/constraint_hwnas_config.yaml
+++ b/tests/integration_tests/test_configs/constraint_hwnas_config.yaml
@@ -1,0 +1,5 @@
+HWNASConfig:
+  host_processor: "auto" 
+  max_search_trials: 10
+  top_n_models: 1
+  hw_constraints: {"max_flops": 1000, "max_params": 100}

--- a/tests/integration_tests/test_configs/hwnas_config.yaml
+++ b/tests/integration_tests/test_configs/hwnas_config.yaml
@@ -8,5 +8,5 @@ HWNASConfig:
   max_search_trials: 2
 
   #The number of top models returned by HW-NAS.
-  top_n_models: 1
+  top_n_models: 2
 

--- a/tests/integration_tests/test_hw_nas_setup_and_search.py
+++ b/tests/integration_tests/test_hw_nas_setup_and_search.py
@@ -38,7 +38,6 @@ class TestHWNasSetupAndSearch:
             "tests/integration_tests/test_experiment"
         )
         self.model_name = "ts_model_0.pt"
-        self.hwnas_cfg = HWNASConfig()
         self.deploy_cfg = DeploymentConfig(
             Path("tests/integration_tests/test_configs/deployment_config.yaml")
         )
@@ -50,8 +49,18 @@ class TestHWNasSetupAndSearch:
         )
         search_space = CombinedSearchSpace(search_space)
         self.RPI5explorer.generate_search_space(search_space)
-        top_k_models = self.RPI5explorer.search(self.hwnas_cfg)
+        top_k_models = self.RPI5explorer.search(HWNASConfig(config_path=Path("tests/integration_tests/test_configs/hwnas_config.yaml")))
         assert len(top_k_models) == 2
+    
+    def test_constraint_search(self):
+        self.setUp()
+        search_space = yml_to_dict(
+            Path("elasticai/explorer/hw_nas/search_space/search_space.yml")
+        )
+        search_space = CombinedSearchSpace(search_space)
+        self.RPI5explorer.generate_search_space(search_space)
+        top_k_models = self.RPI5explorer.search(HWNASConfig(config_path=Path("tests/integration_tests/test_configs/constraint_hwnas_config.yaml")))
+        assert len(top_k_models) == 0
 
     def test_generate_for_hw_platform(self):
         self.setUp()


### PR DESCRIPTION
- Habe in der HWNASConfig ein neues Feld hinzugefügt: hw_constraints: {"max_flops": ..., "max_params": ...}
- Diese werden in der hw_nas.search() als Filter für die Suchstrategie verwendet
- Ich teste, indem ich unerfüllbare Einschränkungen festlege und erwarte, dass kein einziges Modell gesamplet werden kann, das diese erfüllt
- U.a. bei dem cost_estimator gab es einen Merge-Konflikt, den ich so aufgelöst habe, dass man (wie zuvor) nur das Model als Argument angeben, jedoch kein Sample mitgeben muss.