### PR TITLE
Added grid and evolutionary search to explorer

### DIFF
--- a/config_files/config_templates/hwnas_config.yaml
+++ b/config_files/config_templates/hwnas_config.yaml
@@ -9,6 +9,10 @@ HWNASConfig:
 
   # The number of top models returned by HW-NAS.
   top_n_models: 2
+
+  # The search algorithm to use for the HW-NAS.
+  # Options: "random", "grid", "regularized_evolution"
+  search_algorithm: "random"
   
   # The hardware constraints for the search.
   # Currently, only "max_flops" and "max_params" are supported.

--- a/elasticai/explorer/config.py
+++ b/elasticai/explorer/config.py
@@ -73,6 +73,7 @@ class HWNASConfig(Config):
         self._original_yaml_dict: dict = self._parse_optional("HWNASConfig", {})
         self.host_processor: str = self._parse_optional("host_processor", "auto")
         self.hw_constraints: dict = self._parse_optional("hw_constraints", {})
+        self.search_algorithm: str = self._parse_optional("search_algorithm", "random")
         if self.host_processor == "auto":
             self.host_processor = "cuda" if torch.cuda.is_available() else "cpu"
         self.max_search_trials: int = self._parse_optional("max_search_trials", 6)

--- a/tests/integration_tests/test_configs/evolution_hwnas_config.yaml
+++ b/tests/integration_tests/test_configs/evolution_hwnas_config.yaml
@@ -1,0 +1,15 @@
+#HWNASConfig that defines the HW-Nas Behavior.
+#If parameters are not specified inside the config, they are set to default values.
+HWNASConfig:
+  #Processor type (cpu, cuda:n) of the host, the experiment should run on.
+  host_processor: "auto" 
+
+  #The search trials the HW-NAS should do at max.
+  max_search_trials: 2
+
+  #The number of top models returned by HW-NAS.
+  top_n_models: 2
+
+  #The search strategy to use for the HW-NAS experiment.
+  #Options: random, grid, regularized_evolution
+  search_strategy: "regularized_evolution"

--- a/tests/integration_tests/test_configs/grid_hwnas_config.yaml
+++ b/tests/integration_tests/test_configs/grid_hwnas_config.yaml
@@ -1,0 +1,15 @@
+#HWNASConfig that defines the HW-Nas Behavior.
+#If parameters are not specified inside the config, they are set to default values.
+HWNASConfig:
+  #Processor type (cpu, cuda:n) of the host, the experiment should run on.
+  host_processor: "auto" 
+
+  #The search trials the HW-NAS should do at max.
+  max_search_trials: 2
+
+  #The number of top models returned by HW-NAS.
+  top_n_models: 2
+
+  #The search strategy to use for the HW-NAS experiment.
+  #Options: random, grid, regularized_evolution
+  search_strategy: "grid"

--- a/tests/integration_tests/test_hw_nas_setup_and_search.py
+++ b/tests/integration_tests/test_hw_nas_setup_and_search.py
@@ -42,7 +42,7 @@ class TestHWNasSetupAndSearch:
             Path("tests/integration_tests/test_configs/deployment_config.yaml")
         )
 
-    def test_search(self):
+    def test_random_search(self):
         self.setUp()
         search_space = yml_to_dict(
             Path("elasticai/explorer/hw_nas/search_space/search_space.yml")
@@ -50,6 +50,28 @@ class TestHWNasSetupAndSearch:
         search_space = CombinedSearchSpace(search_space)
         self.RPI5explorer.generate_search_space(search_space)
         top_k_models = self.RPI5explorer.search(HWNASConfig(config_path=Path("tests/integration_tests/test_configs/hwnas_config.yaml")))
+        assert len(top_k_models) == 2
+    
+    def test_grid_search(self):
+        self.setUp()
+        search_space = yml_to_dict(
+            Path("elasticai/explorer/hw_nas/search_space/search_space.yml")
+        )
+        search_space = CombinedSearchSpace(search_space)
+        self.RPI5explorer.generate_search_space(search_space)
+        top_k_models = self.RPI5explorer.search(HWNASConfig(config_path=Path("tests/integration_tests/test_configs/grid_hwnas_config.yaml")))
+        # TODO: Check if the grid search is actually configured in NNI
+        assert len(top_k_models) == 2
+    
+    def test_regularized_evolution_search(self):
+        self.setUp()
+        search_space = yml_to_dict(
+            Path("elasticai/explorer/hw_nas/search_space/search_space.yml")
+        )
+        search_space = CombinedSearchSpace(search_space)
+        self.RPI5explorer.generate_search_space(search_space)
+        top_k_models = self.RPI5explorer.search(HWNASConfig(config_path=Path("tests/integration_tests/test_configs/evolution_hwnas_config.yaml")))
+        # TODO: Check if the evolutionary search is actually configured in NNI
         assert len(top_k_models) == 2
     
     def test_constraint_search(self):


### PR DESCRIPTION
Currently, the RegularizedEvolution is initialized with a default configuration. We should add the option to configure this via the HWNASConfig later.

If you're wondering over the `experiment.config.trial_concurrency = num_cpus // 2`: that is to speed up search.
Currently, we can't use GPU (see #107), thus I resort to CPU. I could remove it from the pull request, if you'd prefer that.