### PR TITLE
PyTorch layer implementations for building LSTM autoencoders

### DIFF
--- a/elasticai/explorer/hw_nas/search_space/operations.py
+++ b/elasticai/explorer/hw_nas/search_space/operations.py
@@ -7,6 +7,70 @@ from nni.mutable import MutableExpression, ensure_frozen, Mutable
 from nni.nas.nn.pytorch import Repeat, MutableConv2d, MutableLinear, ModelSpace
 from numpy import block
 from torch import nn
+import torch
+
+class GaussianDropout(nn.Module):
+    def __init__(self, p=0.5):
+        super(GaussianDropout, self).__init__()
+        if p < 0 or p >= 1:
+            raise Exception("p value should accomplish 0 <= p < 1")
+        self.p = p
+        
+    def forward(self, x):
+        if self.training:
+            stddev = (self.p / (1.0 - self.p))**0.5
+            epsilon = torch.randn_like(x) * stddev
+            return x * epsilon
+        else:
+            return x
+
+
+class LambdaLayer(nn.Module):
+    def __init__(self, func):
+        super(LambdaLayer, self).__init__()
+        self.func = func
+    def forward(self, x):
+        return self.func(x)
+
+
+class TimeDistributed(nn.Module):
+    def __init__(self, module, batch_first=False):
+        super(TimeDistributed, self).__init__()
+        self.module = module
+        self.batch_first = batch_first
+
+    def forward(self, x):
+
+        if len(x.size()) <= 2:
+            return self.module(x)
+
+        # Squash samples and timesteps into a single axis
+        x_reshape = x.contiguous().view(-1, x.size(-1))  # (samples * timesteps, input_size)
+
+        y = self.module(x_reshape)
+
+        y = y.contiguous().view(x.size(0), -1, y.size(-1))  # (samples, timesteps, output_size)
+
+        if not self.batch_first:
+            y = y.transpose(0, 1).contiguous()  # transpose to (timesteps, samples, output_size)
+
+        return y
+
+
+@torch.no_grad
+def step_with_update_clip_(optimizer, value=1.0):
+
+    # extract parameters from optimizer
+    params: list[torch.Tensor] = [p for g in optimizer.param_groups for p in g['params'] if p.grad is not None]
+    params_before = [p.clone() for p in params] # store parameters before step
+    optimizer.step() # update parameters
+
+    # update is difference in parameters before and after step, apply clipping to it
+    clipped_update = [torch.clip(p - p_before, -value, value) for p, p_before in zip(params, params_before)]
+
+    # revert parameters and add clipped update instead
+    for p, p_before, u in zip(params, params_before, clipped_update):
+        p.set_(p_before + u) # type: ignore
 
 
 class BlockFactory:


### PR DESCRIPTION
PyTorch implementations for Keras layers `GaussianDropout`, `LambdaLayer` and `TimeDistributed` as well as `optimizer.clipvalue` workaround.

Example use of LambdaLayer in LSTM Autoencoder:

```
LambdaLayer(lambda x: torch.Tensor.reshape(x, x[:, -1, :]))  # "return_sequences=False" in keras.layers.LSTM
LambdaLayer(lambda x: torch.Tensor.repeat(x, self.window_size))  # alternative to keras.layers.RepeatVector
```