### PR TITLE
feat: support depthwise-separable layer

### DIFF
--- a/elasticai/explorer/hw_nas/search_space/layer_builder.py
+++ b/elasticai/explorer/hw_nas/search_space/layer_builder.py
@@ -68,26 +68,64 @@ class ConvLayer(LayerBuilder):
     def get_last_layer(self, input_shape, search_parameters: dict, output_shape):
         return self.build_layer(input_shape, search_parameters)
 
+    def validate_groups(
+        self,
+        in_channels,
+        out_channels,
+        groups,
+    ):
+
+        if in_channels % groups != 0:
+            raise ValueError(
+                f"in_channels={in_channels} must be divisible by groups={groups}"
+            )
+
+        if out_channels % groups != 0:
+            raise ValueError(
+                f"out_channels={out_channels} must be divisible by groups={groups}"
+            )
+
+    def get_out_channels_and_groups(self, input_shape, search_parameters: dict):
+        groups = search_parameters.get("groups", 1)
+        out_channels = search_parameters.get("out_channels", input_shape[0])
+
+        if groups == "depthwise":
+            groups = input_shape[0]
+            out_channels = input_shape[0]
+        self.validate_groups(input_shape[0], out_channels, groups)
+        return out_channels, groups
+
+    def get_padding(self, search_parameters: dict):
+        padding = search_parameters.get("padding", 0)
+        if search_parameters.get("stride", 1) != 1 and padding == "same":
+            padding = 0
+        return padding
+
     def build_layer(self, input_shape, search_parameters: dict):
 
         stride = search_parameters.get("stride", 1)
-        padding = search_parameters.get("padding", 0)
-        if stride != 1 and padding == "same":
-            padding = 0
+
+        out_channels, groups = self.get_out_channels_and_groups(
+            input_shape, search_parameters
+        )
+        padding = self.get_padding(search_parameters)
+
         output_shape = calculate_output_shape(
             input_shape,
             search_parameters["kernel_size"],
             stride,
             padding=padding,
-            out_channels=search_parameters["out_channels"],
+            out_channels=out_channels,
             layer_type=self.layer_type,
         )
+
         conv = self.conv_class(
             input_shape[0],
-            search_parameters["out_channels"],
+            out_channels,
             search_parameters["kernel_size"],
             stride,
             padding=padding,
+            groups=groups,
         )
 
         return conv, output_shape

--- a/tests/integration_tests/samples/depthwise_separable_sp.yaml
+++ b/tests/integration_tests/samples/depthwise_separable_sp.yaml
@@ -1,0 +1,26 @@
+input: [3, 28, 28]
+output: 10
+sequence:
+  - block: "1"
+    op_candidates: "depthwise-separable"
+  - block:  "2"
+    op_candidates:  "linear"
+    linear:
+      width: 32
+      activation: "sigmoid"
+
+composites:
+  depthwise-separable:
+    sequence:
+      - block: "dw"
+        op_candidates: "conv2d"
+        conv2d:
+          kernel_size: [3, 4]
+          stride: [1,2 ]
+          groups: "depthwise"
+      - block: "pw"
+        op_candidates: "conv2d"
+        conv2d:
+          kernel_size: 1
+          stride: 1
+          out_channels: 10

--- a/tests/integration_tests/test_depthwise_separable.py
+++ b/tests/integration_tests/test_depthwise_separable.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from optuna.trial import FixedTrial
+
+from elasticai.explorer.hw_nas.hw_nas import sample_and_create_model
+from elasticai.explorer.hw_nas.search_space.utils import yaml_to_dict
+
+
+def test_depthwise_separable_composite():
+    search_space_cfg = yaml_to_dict(
+        Path("integration_tests/samples/depthwise_separable_sp.yaml")
+    )
+    trial = FixedTrial(
+        {
+            "block_1/l0/depthwise-separable/block_dw/l0/conv2d/kernel_size": 3,
+            "block_1/l0/depthwise-separable/block_dw/l0/conv2d/stride": 2,
+        }
+    )
+    model = sample_and_create_model(trial, search_space_cfg)
+    layer_iter = model.named_children()
+    dw = next(layer_iter)[1]
+    pw = next(layer_iter)[1]
+    assert dw.out_channels == 3 and dw.groups == 3
+    assert pw.out_channels == 10 and pw.groups == 1 and pw.kernel_size == (1, 1)

--- a/tests/unit_tests/searchspace/test_build_model_from_sample.py
+++ b/tests/unit_tests/searchspace/test_build_model_from_sample.py
@@ -169,7 +169,6 @@ def test_build_conv1d_model():
     sample = OrderedDict({"1": block_1, "2": block_2, "3": block_3})
     in_dim = [2, 20]
     model = construct_model(sample, in_dim, 1)
-    print(model)
     first_part = [
         nn.Sequential(
             nn.Conv1d(in_dim[0], 16, kernel_size=3, stride=1, padding=0), nn.ReLU()
@@ -178,6 +177,67 @@ def test_build_conv1d_model():
         nn.MaxPool1d(kernel_size=3, stride=1),
         nn.ReLU(),
         nn.BatchNorm1d(24),
+    ]
+    states = model.state_dict()
+    input = torch.rand([16, 2, 20])
+    out = nn.Sequential(*first_part)(input)
+    shape = math.prod(out.shape[-2:])
+    expected = nn.Sequential(
+        *first_part, ToLinearAdapter(), nn.Sequential(nn.Linear(shape, 1), nn.Sigmoid())
+    )
+    print(expected)
+    expected.load_state_dict(states)
+    assert torch.equal(expected(input), model(input)) == True
+
+
+def test_depthwise_separable_conv():
+    block_1 = OrderedDict(
+        [
+            (
+                "layerdw",
+                {
+                    "operation": "conv1d",
+                    "params": {
+                        "kernel_size": 3,
+                        "stride": 2,
+                        "groups": "depthwise",
+                        "activation": "relu",
+                    },
+                },
+            ),
+            (
+                "layerpw",
+                {
+                    "operation": "conv1d",
+                    "params": {
+                        "kernel_size": 1,
+                        "out_channels": 10,
+                        "stride": 1,
+                    },
+                },
+            ),
+        ]
+    )
+
+    block_2 = OrderedDict(
+        [("layer1", {"operation": "linear", "params": {"activation": "sigmoid"}})]
+    )
+    sample = OrderedDict({"1": block_1, "2": block_2})
+    in_dim = [2, 20]
+    model = construct_model(sample, in_dim, 1)
+    first_part = [
+        nn.Sequential(
+            nn.Conv1d(
+                in_dim[0],
+                in_dim[0],
+                kernel_size=3,
+                stride=2,
+                padding=0,
+                groups=in_dim[0],
+            ),
+            nn.ReLU(),
+        ),
+        nn.Conv1d(in_dim[0], 10, kernel_size=1, stride=1, padding=0, groups=1),
     ]
     states = model.state_dict()
     input = torch.rand([16, 2, 20])


### PR DESCRIPTION
Conv1d and conv2d now support setting the groups parameter. If groups is set to "depthwise" in the yaml the out_channels and groups will be set to in_channels automatically.