### PR TITLE
193 automate libtorch installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,14 @@ Follow the steps in the Docker documentation: [How do I use Docker SDKs with Doc
 ## Set up your Raspberry Pi 4/5 for Deployment
 To use the Explorer to deploy models on your Raspberry Pi, we recommend using Bookworm 64-Bit as an OS. You also need to enable ssh connections on your RPi and make one initial connection between your host PC and the RPi. Make sure to add you public SSH key to the Raspberry Pi under `~/.ssh/authorized_keys`.
 
-Then install libtorch on your Pi under `/code/libtorch` directly at the root of your system, add this libtorch version also under the same path relative to the docker build context (this should be `docker/code/libtorch`) in the elastic-ai.Explorer. You can find precompiled versions of libtorch for Bookworm on RPi4 and RPi5 here (https://uni-duisburg-essen.sciebo.de/s/9aiYf5Y2NABtdQb).
+libtorch is required both on the Pi (`/code/libtorch`) and in the docker build context on your host (`docker/code/libtorch`). The correct version will be downloaded automatically if you set `pi_model` on your `CompilerParams` to `"rpi4"` or `"rpi5"`.
 
-Ensure a `data` directory exists on the Raspberry Pi user's home directory.
+Precompiled libtorch builds for Bookworm on RPi4/RPi5 are hosted on [Sciebo](https://uni-duisburg-essen.sciebo.de/s/9aiYf5Y2NABtdQb).
+
+You can also trigger the automatic install ahead of time via the CLI:
+```
+python -m elasticai.explorer.platforms.deployment.libtorch_installer {rpi4|rpi5} [--docker] [--pi-host HOST] [--pi-user USER]
+```
 
 After this you can use the System Tests by creating your own system_test_settings.toml as shown in example_system_test_settings.toml in the system test folder. Similarly, you can use the example (pi_example.py) by adding your RPi's credentials to the SSHParams. 
 

--- a/elasticai/explorer/explorer.py
+++ b/elasticai/explorer/explorer.py
@@ -173,7 +173,7 @@ class Explorer:
             measurement_source_path_by_metric:
                 Dictionary of source code paths of the programs used for taking
                 measurements, keyed by the corresponding measured metric.
-                For example: measurement_program_path_by_metric = {Metric.ACCURACY: Path("/path/to/measure_accuracy.cpp")}
+                For example: measurement_source_path_by_metric = {Metric.ACCURACY: Path("/path/to/measure_accuracy.cpp")}
             data_spec:
                 Specification of the dataset to install on the target device
                 for on-device measurements.

--- a/elasticai/explorer/explorer.py
+++ b/elasticai/explorer/explorer.py
@@ -166,14 +166,17 @@ class Explorer:
         )
 
     def hw_setup_on_target(
-        self, metric_to_source: dict[Metric, Path], data_spec: data.DatasetSpecification
+        self, measurement_source_path_by_metric: dict[Metric, Path], data_spec: data.DatasetSpecification
     ):
         """
         Args:
-            path_to_testdata: Path to testdata. Format depends on the HWManager implementation. This is not here anymore
-            metric_to_source: Dictionary mapping Metric to source code Path inside the docker context. this doesn't explain anything
-              E.g.: metric_to_source = {Metric.ACCURACY: Path("/path/to/measure_accuracy.cpp")}
-              :param data_spec: this is missing
+            measurement_source_path_by_metric:
+                Dictionary of source code paths of the programs used for taking
+                measurements, keyed by the corresponding measured metric.
+                For example: measurement_program_path_by_metric = {Metric.ACCURACY: Path("/path/to/measure_accuracy.cpp")}
+            data_spec:
+                Specification of the dataset to install on the target device
+                for on-device measurements.
 
         """
         self.logger.info("Setup Hardware target for experiments.")
@@ -186,7 +189,7 @@ class Explorer:
 
         self.hw_manager.install_dataset_on_target(data_spec)
 
-        for metric, source in metric_to_source.items():
+        for metric, source in measurement_source_path_by_metric.items():
             self.logger.info(f"Installing program for {metric.name}: {source}")
             self.hw_manager.install_code_on_target(source, metric)
 

--- a/elasticai/explorer/platforms/deployment/compiler.py
+++ b/elasticai/explorer/platforms/deployment/compiler.py
@@ -72,12 +72,8 @@ class RPICompiler(Compiler):
         if self._is_libtorch_available():
             return
         if self.pi_model is None:
-            self.logger.warning(
-                f"libtorch not found in build context ({self.context_path / self.libtorch_path}) and no pi_model set in CompilerParams",
-            )
+            self.logger.warning(f"libtorch not found in build context ({self.context_path / self.libtorch_path}) and no pi_model set in CompilerParams",)
             return
-
-        self.logger.info("libtorch not found — downloading for %s...", self.pi_model)
         setup_docker_libtorch(PiModel(self.pi_model))
 
     def compile_code(self, source: Path) -> Path:

--- a/elasticai/explorer/platforms/deployment/compiler.py
+++ b/elasticai/explorer/platforms/deployment/compiler.py
@@ -2,8 +2,11 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import logging
 from pathlib import Path
+from typing import Optional
 
 from python_on_whales import docker
+
+from elasticai.explorer.platforms.deployment.libtorch_installer import PiModel, setup_docker_libtorch
 
 from settings import ROOT_DIR
 
@@ -14,6 +17,7 @@ class CompilerParams:
     library_path: Path = Path("./code/libtorch")
     path_to_dockerfile: Path = ROOT_DIR / "docker" / "Dockerfile.pibase"
     build_context: Path = ROOT_DIR / "docker"
+    pi_model: Optional[str] = None
 
 
 class Compiler(ABC):
@@ -41,8 +45,10 @@ class RPICompiler(Compiler):
         self.path_to_dockerfile: Path = Path(compiler_params.path_to_dockerfile)
         self.context_path: Path = Path(compiler_params.build_context)
         self.libtorch_path: Path = Path(compiler_params.library_path)
+        self.pi_model: Optional[str] = compiler_params.pi_model
         if not self.is_setup():
             self.setup()
+        self._ensure_libtorch()
 
     def is_setup(self) -> bool:
         return bool(docker.images(self.image_name))
@@ -54,6 +60,25 @@ class RPICompiler(Compiler):
             self.context_path, file=self.path_to_dockerfile, tags=self.image_name
         )
         self.logger.debug("Crosscompiler available now.")
+
+    def _is_libtorch_available(self) -> bool:
+        libtorch_dir = (self.context_path / self.libtorch_path).resolve()
+        if not libtorch_dir.exists():
+            return False
+        real_contents = [e for e in libtorch_dir.iterdir() if not e.name.startswith("._")]
+        return bool(real_contents)
+
+    def _ensure_libtorch(self) -> None:
+        if self._is_libtorch_available():
+            return
+        if self.pi_model is None:
+            self.logger.warning(
+                f"libtorch not found in build context ({self.context_path / self.libtorch_path}) and no pi_model set in CompilerParams",
+            )
+            return
+
+        self.logger.info("libtorch not found — downloading for %s...", self.pi_model)
+        setup_docker_libtorch(PiModel(self.pi_model))
 
     def compile_code(self, source: Path) -> Path:
         docker.build(

--- a/elasticai/explorer/platforms/deployment/compiler.py
+++ b/elasticai/explorer/platforms/deployment/compiler.py
@@ -63,16 +63,13 @@ class RPICompiler(Compiler):
 
     def _is_libtorch_available(self) -> bool:
         libtorch_dir = (self.context_path / self.libtorch_path).resolve()
-        if not libtorch_dir.exists():
-            return False
-        real_contents = [e for e in libtorch_dir.iterdir() if not e.name.startswith("._")]
-        return bool(real_contents)
+        return libtorch_dir.is_dir() and any(libtorch_dir.iterdir())
 
     def _ensure_libtorch(self) -> None:
         if self._is_libtorch_available():
             return
         if self.pi_model is None:
-            self.logger.warning(f"libtorch not found in build context ({self.context_path / self.libtorch_path}) and no pi_model set in CompilerParams",)
+            self.logger.warning(f"libtorch not found in build context ({self.context_path / self.libtorch_path}) and no pi_model set in CompilerParams")
             return
         setup_docker_libtorch(PiModel(self.pi_model))
 

--- a/elasticai/explorer/platforms/deployment/hw_manager.py
+++ b/elasticai/explorer/platforms/deployment/hw_manager.py
@@ -106,6 +106,7 @@ class RPiHWManager(HWManager):
             tar.add(dataset_dir, arcname=dataset_dir.name)
 
         self.target.put_file(archive_name, ".")
+        self.target.run_command("mkdir -p data")
         self.target.run_command(f"tar -xzf {archive_name.name} -C data")
 
     def measure_metric(self, metric: Metric, path_to_model: Path) -> dict:

--- a/elasticai/explorer/platforms/deployment/hw_manager.py
+++ b/elasticai/explorer/platforms/deployment/hw_manager.py
@@ -7,7 +7,9 @@ from pathlib import Path
 
 import shutil
 import tarfile
-from elasticai.explorer.platforms.deployment.compiler import Compiler
+
+from elasticai.explorer.platforms.deployment.compiler import Compiler, RPICompiler
+from elasticai.explorer.platforms.deployment.libtorch_installer import PiModel, install_libtorch_on_pi
 from elasticai.explorer.platforms.deployment.device_communication import (
     Host,
     PicoHost,
@@ -59,7 +61,26 @@ class RPiHWManager(HWManager):
         self.logger.info("Initializing PI Hardware Manager...")
         super().__init__(target, compiler)
 
+    def _pi_has_libtorch(self) -> bool:
+        try:
+            result = self.target.run_command(
+                "test -d /code/libtorch && find /code/libtorch -mindepth 1 -maxdepth 1 | grep -q . && echo yes || echo no"
+            )
+            return result.strip() == "yes"
+        except Exception:
+            return False
+
+    def _ensure_libtorch_on_pi(self) -> None:
+        if self._pi_has_libtorch():
+            return
+        if not isinstance(self.compiler, RPICompiler) or self.compiler.pi_model is None:
+            self.logger.warning("libtorch not found on Pi and no pi_model set in CompilerParams")
+            return
+
+        install_libtorch_on_pi(self.target, PiModel(self.compiler.pi_model))
+
     def install_code_on_target(self, source: Path, metric: Metric):
+        self._ensure_libtorch_on_pi()
         if source.is_relative_to(DOCKER_CONTEXT_DIR):
             relative_path = Path("/" + str(source.relative_to(DOCKER_CONTEXT_DIR)))
         else:

--- a/elasticai/explorer/platforms/deployment/hw_manager.py
+++ b/elasticai/explorer/platforms/deployment/hw_manager.py
@@ -63,10 +63,8 @@ class RPiHWManager(HWManager):
 
     def _pi_has_libtorch(self) -> bool:
         try:
-            result = self.target.run_command(
-                "test -d /code/libtorch && find /code/libtorch -mindepth 1 -maxdepth 1 | grep -q . && echo yes || echo no"
-            )
-            return result.strip() == "yes"
+            result = self.target.run_command("ls -A /code/libtorch 2>/dev/null")
+            return bool(result.strip())
         except Exception:
             return False
 
@@ -76,7 +74,7 @@ class RPiHWManager(HWManager):
         if not isinstance(self.compiler, RPICompiler) or self.compiler.pi_model is None:
             self.logger.warning("libtorch not found on Pi and no pi_model set in CompilerParams")
             return
-
+            
         install_libtorch_on_pi(self.target, PiModel(self.compiler.pi_model))
 
     def install_code_on_target(self, source: Path, metric: Metric):
@@ -90,7 +88,6 @@ class RPiHWManager(HWManager):
         self.target.put_file(path_to_executable, ".")
 
     def install_dataset_on_target(self, dataset_spec: DatasetSpecification):
-
         if dataset_spec.deployable_dataset_path:
             dataset_dir = dataset_spec.deployable_dataset_path
         elif isinstance(dataset_spec.dataset, RootedDataset):

--- a/elasticai/explorer/platforms/deployment/libtorch_installer.py
+++ b/elasticai/explorer/platforms/deployment/libtorch_installer.py
@@ -1,0 +1,152 @@
+import shutil
+import sys
+import tarfile
+import tempfile
+import zipfile
+from enum import Enum
+from pathlib import Path
+
+import owncloud
+
+from elasticai.explorer.platforms.deployment.device_communication import Host, RPiHost, SSHParams
+from settings import DOCKER_CONTEXT_DIR
+
+LIBTORCH_SCIEBO_URL = "https://uni-duisburg-essen.sciebo.de/s/9aiYf5Y2NABtdQb"
+
+LIBTORCH_ARCHIVES: dict[str, str] = {
+    "rpi4": "libtorch-v2.5.1-rpi4-bookworm.tar.gz",
+    "rpi5": "libtorch-v2.6.0-rpi5-bookworm.zip",
+}
+
+class PiModel(Enum):
+    RPi4 = "rpi4"
+    RPi5 = "rpi5"
+
+
+def _open_sciebo_client() -> owncloud.Client:
+    return owncloud.Client.from_public_link(LIBTORCH_SCIEBO_URL)
+
+
+def _raw_extract(archive_path: Path, dest: Path) -> None:
+    if ".tar" in archive_path.name:
+        with tarfile.open(archive_path) as tf:
+            tf.extractall(dest)
+    elif archive_path.name.endswith(".zip"):
+        with zipfile.ZipFile(archive_path) as zf:
+            zf.extractall(dest)
+    else:
+        raise ValueError(f"Unsupported format: {archive_path.name}")
+
+
+def _extract_to(archive_path: Path, target_dir: Path) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        _raw_extract(archive_path, tmp_path)
+
+        src = tmp_path / "libtorch"
+
+        if not src.exists() or not src.is_dir():
+            raise FileNotFoundError(f"No 'libtorch' directory in: {archive_path.name}'")
+
+        target_dir.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(src), str(target_dir))
+
+
+def _download_archive(archive_name: str) -> Path:
+    tmp_dir = tempfile.mkdtemp()
+    archive_path = Path(tmp_dir) / archive_name
+    client = _open_sciebo_client()
+    client.get_file(archive_name, str(archive_path))
+    client.logout()
+    return archive_path
+
+
+def _pi_install_command(archive_name: str) -> str:
+    if archive_name.endswith(".zip"):
+        extract = f'python3 -m zipfile -e ~/{archive_name} "$TMP"'
+    else:
+        extract = f'tar xzf ~/{archive_name} -C "$TMP"'
+
+    return (
+        "set -e && "
+        'TMP="$(mktemp -d)" && '
+        f"{extract} && "
+        "sudo rm -rf /code/libtorch && "
+        "sudo mkdir -p /code && "
+        'sudo mv "$TMP/libtorch" /code/libtorch && '
+        f'rm -rf "$TMP" ~/{archive_name}'
+    )
+
+
+def download_libtorch(pi_model: PiModel, target_dir: Path) -> None:
+    archive_name = LIBTORCH_ARCHIVES[pi_model.value]
+    archive_path = _download_archive(archive_name)
+    try:
+        if target_dir.exists():
+            shutil.rmtree(target_dir)
+        _extract_to(archive_path, target_dir)
+    finally:
+        shutil.rmtree(archive_path.parent, ignore_errors=True)
+
+
+def setup_docker_libtorch(pi_model: PiModel) -> Path:
+    target = DOCKER_CONTEXT_DIR / "code" / "libtorch"
+    download_libtorch(pi_model, target)
+    return target
+
+
+def install_libtorch_on_pi(pi_host: Host, pi_model: PiModel) -> None:
+    archive_name = LIBTORCH_ARCHIVES[pi_model.value]
+    archive_path = _download_archive(archive_name)
+    try:
+        pi_host.put_file(archive_path, ".")
+    finally:
+        shutil.rmtree(archive_path.parent, ignore_errors=True)
+    pi_host.run_command(_pi_install_command(archive_name))
+
+
+def _parse_args(argv: list[str]) -> dict:
+    _args: dict = {"model": None, "docker": False, "pi_host": None, "pi_user": "pi"}
+    i = 0
+    while i < len(argv):
+        if argv[i] in ("rpi4", "rpi5"):
+            _args["model"] = argv[i]
+        elif argv[i] == "--docker":
+            _args["docker"] = True
+        elif argv[i] == "--pi-host":
+            i += 1
+            _args["pi_host"] = argv[i]
+        elif argv[i] == "--pi-user":
+            i += 1
+            _args["pi_user"] = argv[i]
+        else:
+            raise ValueError(f"Unknown argument: {argv[i]}")
+        i += 1
+    return _args
+
+
+if __name__ == "__main__":
+    """
+        CLI Usage: 
+        $ python -m elasticai.explorer.platforms.deployment.libtorch_installer {rpi4|rpi5} [--docker] [--pi-host HOST] [--pi-user USER]
+        --docker          Extract into Docker build context
+        --pi-host HOST    Pi hostname for SSH installation
+        --pi-user USER    Pi SSH username (default: pi)
+    """
+
+    args = _parse_args(sys.argv[1:])
+
+    if args["model"] is None:
+        raise ValueError("Pi model (rpi4 or rpi5) is required")
+
+    if not args["docker"] and not args["pi_host"]:
+        raise ValueError("Specify at least one of --docker or --pi-host")
+
+    pi_model = PiModel(args["model"])
+
+    if args["docker"]:
+        path = setup_docker_libtorch(pi_model)
+
+    if args["pi_host"]:
+        host = RPiHost(SSHParams(hostname=args["pi_host"], username=args["pi_user"]))
+        install_libtorch_on_pi(host, pi_model)

--- a/elasticai/explorer/platforms/deployment/libtorch_installer.py
+++ b/elasticai/explorer/platforms/deployment/libtorch_installer.py
@@ -34,6 +34,9 @@ def _raw_extract(archive_path: Path, dest: Path) -> None:
     elif archive_path.name.endswith(".zip"):
         with zipfile.ZipFile(archive_path) as zf:
             zf.extractall(dest)
+            top_dir = dest / 'libtorch-v2.6.0-rpi5-bookworm'
+            shutil.move(top_dir / 'libtorch', dest)
+            top_dir.rmdir()
     else:
         raise ValueError(f"Unsupported format: {archive_path.name}")
 
@@ -64,8 +67,10 @@ def _download_archive(archive_name: str) -> Path:
 def _pi_install_command(archive_name: str) -> str:
     if archive_name.endswith(".zip"):
         extract = f'python3 -m zipfile -e ~/{archive_name} "$TMP"'
+        src = f'"$TMP/libtorch-v2.6.0-rpi5-bookworm/libtorch"'
     else:
         extract = f'tar xzf ~/{archive_name} -C "$TMP"'
+        src = '"$TMP/libtorch"'
 
     return (
         "set -e && "
@@ -73,7 +78,7 @@ def _pi_install_command(archive_name: str) -> str:
         f"{extract} && "
         "sudo rm -rf /code/libtorch && "
         "sudo mkdir -p /code && "
-        'sudo mv "$TMP/libtorch" /code/libtorch && '
+        f'sudo mv {src} /code/libtorch && '
         f'rm -rf "$TMP" ~/{archive_name}'
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pandas>=2.2.3",
     "tensorflow==2.20.0",
     "iesude-data",
+    "pyocclient>=0.6",
     "tflite==2.18.0",
     "denspp-offline",
 ]


### PR DESCRIPTION
closes #196 

Added a libtorch installer under deployment tools.

The installer downloads and installs the correct libtorch version from Sciebo the first time code is installed on the target device and when RBiCompiler is set up with CompilerParams.pi_model set to "rpi4" or "rpi5".

The data directory on the rbpi had to be created manually, this is now automated

Refactored metric_to_source  variable name to be more clear and updated the comment

Updated readme.md to correspond with new changes

